### PR TITLE
Phase-1/add/5 - Configure Settings page for General and Search settings

### DIFF
--- a/classes/class-core.php
+++ b/classes/class-core.php
@@ -104,7 +104,7 @@ class Core {
 		$post_types = apply_filters( 'lsx_business_directory_post_types', $this->post_types );
 
 		foreach ( $post_types as $index => $post_type ) {
-			$is_disabled = \cmb2_get_option( 'lsx_health_plan_options', $post_type . '_disabled', false );
+			$is_disabled = \cmb2_get_option( 'lsx_bd_options', $post_type . '_disabled', false );
 
 			if ( true === $is_disabled || 1 === $is_disabled || 'on' === $is_disabled ) {
 				unset( $post_types[ $index ] );

--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -501,6 +501,8 @@ class Setup {
 
 	/**
 	 * Sets the FacetWP variables.
+	 *
+	 * @return  void
 	 */
 	public function set_facetwp_vars() {
 		if ( function_exists( '\FWP' ) ) {


### PR DESCRIPTION
### Description
Configure Settings custom fields using CMB2 for **General** settings as well as **Search** settings. Search settings are set to show only if **LSX Search** plugin is enabled.

### Code changes
- Added functions in **class-setup.php** to configure Settings page to include **General** and **Search** sections.

### Tests done
- All fields save as they should.
- Search section does not show if LSX Search plugin is disabled, but shows if it's enabled.

### Issue
https://github.com/lightspeeddevelopment/lsx-business-directory/issues/5