### PR TITLE
Phase 1/add/6 - Add in the functions to connect the search settings to the LSX Search filters

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -130,7 +130,7 @@ class Admin {
 		$cmb->add_field(
 			array(
 				'name'             => esc_html__( 'Layout option', 'lsx-business-directory' ),
-				'id'               => 'archive_layout',
+				'id'               => 'archive_grid_list',
 				'type'             => 'radio',
 				'show_option_none' => false,
 				'options'          => array(
@@ -139,5 +139,6 @@ class Admin {
 				),
 			)
 		);
+		do_action( 'lsx_bd_settings_section_archive', $this->cmb );
 	}
 }

--- a/classes/class-integrations.php
+++ b/classes/class-integrations.php
@@ -18,6 +18,13 @@ class Integrations {
 	protected static $instance = null;
 
 	/**
+	 * Holds the LSX Search integration functions.
+	 * 
+	 * @var object \lsx\business_directory\classes\Frontend();
+	 */
+	public $lsx_search;
+
+	/**
 	 * This holds the current facet info.
 	 *
 	 * @var array
@@ -28,8 +35,9 @@ class Integrations {
 	 * Contructor
 	 */
 	public function __construct() {
-		// We do BD Search setting only at 'admin_init', because we need is_plugin_active() function present to check for LSX Search plugin.
-		add_action( 'lsx_bd_settings_page', array( $this, 'configure_settings_search_custom_fields' ), 15, 1 );
+		// Load plugin settings related functionality.
+		require_once LSX_BD_PATH . '/classes/integrations/class-lsx-search.php';
+		$this->lsx_search = integrations\LSX_Search::get_instance();
 	}
 
 	/**
@@ -48,116 +56,5 @@ class Integrations {
 
 		return self::$instance;
 
-	}
-	/**
-	 * Enable Business Directory Search settings only if LSX Search plugin is enabled.
-	 *
-	 * @return  void
-	 */
-	public function configure_settings_search_custom_fields( $cmb ) {
-		if ( is_plugin_active( 'lsx-search/lsx-search.php' ) ) {
-			$prefix = 'businessdirectory';
-			$this->set_facetwp_vars();
-
-			$cmb->add_field(
-				array(
-					'id'          => $prefix . '_settings_search',
-					'type'        => 'title',
-					'name'        => esc_html__( 'Business Directory - Search', 'lsx-business-directory' ),
-					'default'     => esc_html__( 'Business Directory - Search', 'lsx-business-directory' ),
-					'description' => esc_html__( 'Business Directory search related settings.', 'lsx-business-directory' ),
-				)
-			);
-
-			$cmb->add_field(
-				array(
-					'name' => esc_html__( 'Enable Search', 'lsx-business-directory' ),
-					'id'   => $prefix . '_business_search_enable',
-					'type' => 'checkbox',
-				)
-			);
-
-			$cmb->add_field(
-				array(
-					'name'    => esc_html__( 'Layout', 'lsx-business-directory' ),
-					'id'      => $prefix . '_business_search_layout',
-					'type'    => 'select',
-					'options' => array(
-						''    => esc_html__( 'Follow the theme layout', 'lsx-business-directory' ),
-						'1c'  => esc_html__( '1 column', 'lsx-business-directory' ),
-						'2cr' => esc_html__( '2 columns / Content on right', 'lsx-business-directory' ),
-						'2cl' => esc_html__( '2 columns / Content on left', 'lsx-business-directory' ),
-					),
-					'default' => '',
-				)
-			);
-
-			$cmb->add_field(
-				array(
-					'name' => esc_html__( 'Collapse', 'lsx-business-directory' ),
-					'id'   => $prefix . '_business_search_collapse',
-					'type' => 'checkbox',
-				)
-			);
-
-			$cmb->add_field(
-				array(
-					'name' => esc_html__( 'Disable Sorting', 'lsx-business-directory' ),
-					'id'   => $prefix . '_business_search_disable_sorting',
-					'type' => 'checkbox',
-				)
-			);
-
-			$cmb->add_field(
-				array(
-					'name' => esc_html__( 'Disable the Date Option', 'lsx-business-directory' ),
-					'id'   => $prefix . '_business_search_disable_date',
-					'type' => 'checkbox',
-				)
-			);
-
-			$cmb->add_field(
-				array(
-					'name' => esc_html__( 'Display Clear Button', 'lsx-business-directory' ),
-					'id'   => $prefix . '_business_search_clear_button',
-					'type' => 'checkbox',
-				)
-			);
-
-			$cmb->add_field(
-				array(
-					'name' => esc_html__( 'Display Result Count', 'lsx-business-directory' ),
-					'id'   => $prefix . '_business_search_result_count',
-					'type' => 'checkbox',
-				)
-			);
-
-			$cmb->add_field(
-				array(
-					'name'        => esc_html__( 'Facets', 'lsx-business-directory' ),
-					'description' => esc_html__( 'These are the filters that will appear on your archive page.', 'lsx-business-directory' ),
-					'id'          => $prefix . '_business_search_facets',
-					'type'        => 'multicheck',
-					'options'     => $this->facet_data,
-				)
-			);
-		}
-	}
-	/**
-	 * Sets the FacetWP variables.
-	 *
-	 * @return  void
-	 */
-	public function set_facetwp_vars() {
-		if ( function_exists( '\FWP' ) ) {
-			$facet_data = \FWP()->helper->get_facets();
-		}
-
-		$this->facet_data = array();
-		if ( ! empty( $facet_data ) && is_array( $facet_data ) ) {
-			foreach ( $facet_data as $facet ) {
-				$this->facet_data[ $facet['name'] ] = $facet['label'];
-			}
-		}
 	}
 }

--- a/classes/class-integrations.php
+++ b/classes/class-integrations.php
@@ -19,7 +19,7 @@ class Integrations {
 
 	/**
 	 * Holds the LSX Search integration functions.
-	 * 
+	 *
 	 * @var object \lsx\business_directory\classes\Frontend();
 	 */
 	public $lsx_search;

--- a/classes/integrations/class-lsx-search.php
+++ b/classes/integrations/class-lsx-search.php
@@ -1,0 +1,190 @@
+<?php
+namespace lsx\business_directory\classes\integrations;
+
+/**
+ * LSX Search Integration class
+ *
+ * @package lsx-business-directory
+ */
+class LSX_Search {
+
+	/**
+	 * Holds class instance
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      object \lsx\business_directory\classes\LSX_Search()
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Contructor
+	 */
+	public function __construct() {
+		// We do BD Search setting only at 'admin_init', because we need is_plugin_active() function present to check for LSX Search plugin.
+		add_action( 'lsx_bd_settings_page', array( $this, 'configure_settings_search_engine_fields' ), 15, 1 );
+		add_action( 'lsx_bd_settings_section_archive', array( $this, 'configure_settings_search_archive_fields' ), 15, 1 );
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return    object \lsx\business_directory\classes\LSX_Search()    A single instance of this class.
+	 */
+	public static function get_instance() {
+		// If the single instance hasn't been set, set it now.
+		if ( null == self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Enable Business Directory Search settings only if LSX Search plugin is enabled.
+	 *
+	 * @return  void
+	 */
+	public function configure_settings_search_engine_fields( $cmb ) {
+		$this->search_fields( $cmb, 'engine' );
+	}
+
+	/**
+	 * Enable Business Directory Search settings only if LSX Search plugin is enabled.
+	 *
+	 * @return  void
+	 */
+	public function configure_settings_search_archive_fields( $cmb ) {
+		$this->search_fields( $cmb, 'archive' );
+	}
+
+	/**
+	 * Enable Business Directory Search settings only if LSX Search plugin is enabled.
+	 *
+	 * @return  void
+	 */
+	public function search_fields( $cmb, $section ) {
+		if ( is_plugin_active( 'lsx-search/lsx-search.php' ) ) {
+			$this->set_facetwp_vars();
+			if ( 'engine' === $section ) {
+				$cmb->add_field(
+					array(
+						'id'          => 'settings_' . $section . '_search',
+						'type'        => 'title',
+						'name'        => esc_html__( 'Search', 'lsx-business-directory' ),
+						'default'     => esc_html__( 'Search', 'lsx-business-directory' ),
+						'description' => esc_html__( 'If you have created an supplemental engine via SearchWP, then you can control the search settings here.', 'lsx-business-directory' ),
+					)
+				);
+			}
+
+			$cmb->add_field(
+				array(
+					'name' => esc_html__( 'Enable Search', 'lsx-business-directory' ),
+					'id'   => $section . '_search_enable',
+					'type' => 'checkbox',
+				)
+			);
+
+			$cmb->add_field(
+				array(
+					'name'    => esc_html__( 'Layout', 'lsx-business-directory' ),
+					'id'      => $section . '_search_layout',
+					'type'    => 'select',
+					'options' => array(
+						''    => esc_html__( 'Follow the theme layout', 'lsx-business-directory' ),
+						'1c'  => esc_html__( '1 column', 'lsx-business-directory' ),
+						'2cr' => esc_html__( '2 columns / Content on right', 'lsx-business-directory' ),
+						'2cl' => esc_html__( '2 columns / Content on left', 'lsx-business-directory' ),
+					),
+					'default' => '',
+				)
+			);
+
+			if ( 'engine' === $section ) {
+				$cmb->add_field(
+					array(
+						'name'             => esc_html__( 'Grid vs List', 'lsx-business-directory' ),
+						'id'               => $section . '_grid_list',
+						'type'             => 'radio',
+						'show_option_none' => false,
+						'options'          => array(
+							'grid' => esc_html__( 'Grid', 'lsx-business-directory' ),
+							'list' => esc_html__( 'List', 'lsx-business-directory' ),
+						),
+						'default' => 'list',
+					)
+				);
+			}
+
+			$cmb->add_field(
+				array(
+					'name' => esc_html__( 'Collapse', 'lsx-business-directory' ),
+					'id'   => $section . '_search_collapse',
+					'type' => 'checkbox',
+				)
+			);
+
+			$cmb->add_field(
+				array(
+					'name' => esc_html__( 'Disable Sorting', 'lsx-business-directory' ),
+					'id'   => $section . '_search_disable_sorting',
+					'type' => 'checkbox',
+				)
+			);
+
+			$cmb->add_field(
+				array(
+					'name' => esc_html__( 'Disable the Date Option', 'lsx-business-directory' ),
+					'id'   => $section . '_search_disable_date',
+					'type' => 'checkbox',
+				)
+			);
+
+			$cmb->add_field(
+				array(
+					'name' => esc_html__( 'Display Clear Button', 'lsx-business-directory' ),
+					'id'   => $section . '_search_clear_button',
+					'type' => 'checkbox',
+				)
+			);
+
+			$cmb->add_field(
+				array(
+					'name' => esc_html__( 'Display Result Count', 'lsx-business-directory' ),
+					'id'   => $section . '_search_result_count',
+					'type' => 'checkbox',
+				)
+			);
+
+			$cmb->add_field(
+				array(
+					'name'        => esc_html__( 'Facets', 'lsx-business-directory' ),
+					'description' => esc_html__( 'These are the filters that will appear on your page.', 'lsx-business-directory' ),
+					'id'          => $section . '_search_facets',
+					'type'        => 'multicheck',
+					'options'     => $this->facet_data,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Sets the FacetWP variables.
+	 *
+	 * @return  void
+	 */
+	public function set_facetwp_vars() {
+		if ( function_exists( '\FWP' ) ) {
+			$facet_data = \FWP()->helper->get_facets();
+		}
+
+		$this->facet_data = array();
+		if ( ! empty( $facet_data ) && is_array( $facet_data ) ) {
+			foreach ( $facet_data as $facet ) {
+				$this->facet_data[ $facet['name'] ] = $facet['label'];
+			}
+		}
+	}
+}

--- a/templates/archive-business-directory.php
+++ b/templates/archive-business-directory.php
@@ -24,7 +24,7 @@ get_header(); ?>
 				<?php
 				while ( have_posts() ) :
 					the_post();
-					$layout = lsx_bd_get_option( 'archive_layout' );
+					$layout = lsx_bd_get_option( 'archive_grid_list' );
 					if ( false !== $layout && '' !== $layout && 'grid' === $layout ) {
 						include LSX_BD_PATH . '/templates/single-col-business.php';
 					} else {


### PR DESCRIPTION
### Description of the Change
We have added in a functions which acts as the bridge between our settings and the LSX Search settings array.   It grabs ours and formats and then returns it to LSX serch for use.

I have also split up the search settings into a search engine and the archives filters.

### Screenshots
Archive Settings
![Screenshot 2020-03-11 at 15 40 34](https://user-images.githubusercontent.com/1805603/76423011-d52a4d00-63ae-11ea-9268-8f4cd4f34786.png)

Search Settings
![Screenshot 2020-03-11 at 15 40 40](https://user-images.githubusercontent.com/1805603/76423006-d2c7f300-63ae-11ea-815c-1b679f946608.png)

### Benefits
We can choose different filters to display in the SearchWP supplemental search engine, as opposed to the archive pages.

### Verification Process
 - [ ] Set the archive settings on the LSX Business Directory Demo Site.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues
#6 
