### PR TITLE
Added in the get the archive filter to fix the titles.

### DIFF
--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -27,6 +27,8 @@ class Frontend {
 		add_filter( 'template_include', array( $this, 'archive_template_include' ), 99 );
 		add_filter( 'template_include', array( $this, 'single_template_include' ), 99 );
 		add_filter( 'template_include', array( $this, 'taxonomy_template_include' ), 99 );
+
+		add_filter( 'get_the_archive_title', array( $this, 'get_the_archive_title' ), 100 );
 	}
 
 	/**
@@ -122,5 +124,25 @@ class Frontend {
 			}
 		}
 		return $template;
+	}
+
+	/**
+	 * Remove the "Archives:" from the post type recipes.
+	 *
+	 * @param string $title the term title.
+	 * @return string
+	 */
+	public function get_the_archive_title( $title ) {
+		if ( is_post_type_archive( 'business-directory' ) ) {
+			$title = __( 'Business Directory', 'lsx-health-plan' );
+		}
+		if ( is_tax( array( 'lsx-bd-industry', 'lsx-bd-region' ) ) ) {
+			$queried_object = get_queried_object();
+			if ( isset( $queried_object->name ) ) {
+				$title = $queried_object->name;
+			}
+		}
+		$title = apply_filters( 'lsx_bd_archive_banner_title', $title );
+		return $title;
 	}
 }


### PR DESCRIPTION
### Description of the Change
I have added in a filter to remove the "Archives:" label from the business directory post type archives.

### Benefits
It is more human readable. And a filter has been added so future settings can filter and change this title. `lsx_bd_archive_banner_title`

![Screenshot 2020-03-12 at 07 06 52](https://user-images.githubusercontent.com/1805603/76489091-144cb280-6430-11ea-9e47-a6b1a25b6541.png)

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

