### PR TITLE
Phase 1/add/banners - Single Listing Banners

### DIFF
--- a/classes/admin/class-banners.php
+++ b/classes/admin/class-banners.php
@@ -1,0 +1,40 @@
+<?php
+namespace lsx\business_directory\classes\admin;
+
+/**
+ * Banners Frontend Class
+ *
+ * @package lsx-business-directory
+ */
+class Banners {
+
+	/**
+	 * Holds class instance
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      object \lsx\business_directory\classes\admin\Banners()
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Contructor
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return    object \lsx\business_directory\classes\admin\Banners()    A single instance of this class.
+	 */
+	public static function get_instance() {
+		// If the single instance hasn't been set, set it now.
+		if ( null == self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+}

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -18,9 +18,17 @@ class Admin {
 	protected static $instance = null;
 
 	/**
+	 * Holds the admin banner actions and filters.
+	 *
+	 * @var object \lsx\business_directory\classes\admin\Banners();
+	 */
+	public $banners;
+
+	/**
 	 * Contructor
 	 */
 	public function __construct() {
+		$this->load_classes();
 		// Enqueue scripts for all admin pages.
 		add_action( 'admin_enqueue_scripts', array( $this, 'assets' ) );
 
@@ -38,14 +46,20 @@ class Admin {
 	 * @return    object \lsx\member_directory\classes\Admin()    A single instance of this class.
 	 */
 	public static function get_instance() {
-
 		// If the single instance hasn't been set, set it now.
 		if ( null == self::$instance ) {
 			self::$instance = new self();
 		}
-
 		return self::$instance;
+	}
 
+	/**
+	 * Loads the variable classes and the static classes.
+	 */
+	private function load_classes() {
+		// Load plugin admin related functionality.
+		require_once LSX_BD_PATH . 'classes/frontend/class-banners.php';
+		$this->banners = frontend\Banners::get_instance();
 	}
 
 	/**

--- a/classes/class-business-directory.php
+++ b/classes/class-business-directory.php
@@ -44,6 +44,9 @@ class Business_Directory {
 
 		// Register the custom fields.
 		add_action( 'cmb2_init', array( $this, 'register_banner_custom_fields' ) );
+		add_action( 'cmb2_init', array( $this, 'register_address_custom_fields' ) );
+		add_action( 'cmb2_init', array( $this, 'register_branches_custom_fields' ) );
+		add_action( 'cmb2_init', array( $this, 'register_contact_custom_fields' ) );
 		add_action( 'cmb2_init', array( $this, 'configure_business_directory_custom_fields' ) );
 	}
 
@@ -219,6 +222,85 @@ class Business_Directory {
 	}
 
 	/**
+	 * Registers the Business Directory address custom fields.
+	 *
+	 * @return void
+	 */
+	public function register_address_custom_fields() {
+	}
+
+	/**
+	 * Registers the Business Directory branches custom fields.
+	 *
+	 * @return void
+	 */
+	public function register_branches_custom_fields() {
+	}
+
+	/**
+	 * Registers the Business Directory contact custom fields.
+	 *
+	 * @return void
+	 */
+	public function register_contact_custom_fields() {
+		$cmb_contact = new_cmb2_box(
+			array(
+				'id'           => $this->prefix . '_contact_metabox',
+				'title'        => esc_html__( 'Contact Details.', 'lsx-business-directory' ),
+				'object_types' => array( 'business-directory' ),
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Primary Email.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_primary_email',
+				'type' => 'text_email',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Secondary Email.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_secondary_email',
+				'type' => 'text_email',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Primary Phone.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_primary_phone',
+				'type' => 'text',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Secondary Phone.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_secondary_phone',
+				'type' => 'text',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Fax.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_fax',
+				'type' => 'text',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Website.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_website',
+				'type' => 'text_url',
+			)
+		);
+	}
+
+	/**
 	 * Configure Business Directory custom fields.
 	 *
 	 * @return void
@@ -360,62 +442,6 @@ class Business_Directory {
 				'name' => esc_html__( 'Branch Google Maps Search', 'lsx-business-directory' ),
 				'id'   => 'branch_google_maps_search',
 				'type' => 'text',
-			)
-		);
-
-		$cmb_contact = new_cmb2_box(
-			array(
-				'id'           => $this->prefix . '_contact_metabox',
-				'title'        => esc_html__( 'Contact Details.', 'lsx-business-directory' ),
-				'object_types' => array( 'business-directory' ),
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Primary Email.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_primary_email',
-				'type' => 'text_email',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Secondary Email.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_secondary_email',
-				'type' => 'text_email',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Primary Phone.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_primary_phone',
-				'type' => 'text',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Secondary Phone.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_secondary_phone',
-				'type' => 'text',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Fax.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_fax',
-				'type' => 'text',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Website.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_website',
-				'type' => 'text_url',
 			)
 		);
 	}

--- a/classes/class-business-directory.php
+++ b/classes/class-business-directory.php
@@ -231,7 +231,7 @@ class Business_Directory {
 			array(
 				'name' => esc_html__( 'Subtitle', 'lsx-business-directory' ),
 				'desc' => esc_html__( 'Customize the subtitle for your banner, this will display just below your title.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_banner_title',
+				'id'   => $this->prefix . '_banner_subtitle',
 				'type' => 'text',
 			)
 		);

--- a/classes/class-business-directory.php
+++ b/classes/class-business-directory.php
@@ -47,7 +47,6 @@ class Business_Directory {
 		add_action( 'cmb2_init', array( $this, 'register_address_custom_fields' ) );
 		add_action( 'cmb2_init', array( $this, 'register_branches_custom_fields' ) );
 		add_action( 'cmb2_init', array( $this, 'register_contact_custom_fields' ) );
-		add_action( 'cmb2_init', array( $this, 'configure_business_directory_custom_fields' ) );
 	}
 
 	/**
@@ -309,13 +308,20 @@ class Business_Directory {
 	 * @return void
 	 */
 	public function register_branches_custom_fields() {
+		$cmb_address = new_cmb2_box(
+			array(
+				'id'           => $this->prefix . '_branches_metabox',
+				'title'        => esc_html__( 'Business Branches', 'lsx-business-directory' ),
+				'object_types' => array( 'business-directory' ),
+			)
+		);
+
 		$branches_group_field_id = $cmb_address->add_field(
 			array(
-				'id'          => $this->prefix . '_business_branches',
-				'type'        => 'group',
-				'description' => esc_html__( 'Business Branches', 'lsx-business-directory' ),
-				'repeatable'  => true,
-				'options'     => array(
+				'id'         => $this->prefix . '_business_branches',
+				'type'       => 'group',
+				'repeatable' => true,
+				'options'    => array(
 					'group_title'    => esc_html__( 'Branch {#}', 'lsx-business-directory' ), // since version 1.1.4, {#} gets replaced by row number
 					'add_button'     => esc_html__( 'Add Another Branch', 'lsx-business-directory' ),
 					'remove_button'  => esc_html__( 'Remove Branch', 'lsx-business-directory' ),
@@ -383,7 +389,7 @@ class Business_Directory {
 		$cmb_contact = new_cmb2_box(
 			array(
 				'id'           => $this->prefix . '_contact_metabox',
-				'title'        => esc_html__( 'Contact Details.', 'lsx-business-directory' ),
+				'title'        => esc_html__( 'Business Contact Details', 'lsx-business-directory' ),
 				'object_types' => array( 'business-directory' ),
 			)
 		);
@@ -435,13 +441,5 @@ class Business_Directory {
 				'type' => 'text_url',
 			)
 		);
-	}
-
-	/**
-	 * Configure Business Directory custom fields.
-	 *
-	 * @return void
-	 */
-	public function configure_business_directory_custom_fields() {
 	}
 }

--- a/classes/class-business-directory.php
+++ b/classes/class-business-directory.php
@@ -202,23 +202,37 @@ class Business_Directory {
 				'object_types' => array( 'business-directory' ),
 			)
 		);
-
 		$cmb_images->add_field(
 			array(
-				'name' => esc_html__( 'Banner Image', 'lsx-business-directory' ),
-				'desc' => esc_html__( 'Banner image for a Business', 'lsx-business-directory' ),
+				'name' => esc_html__( 'Image', 'lsx-business-directory' ),
+				'desc' => esc_html__( 'Upload a banner image for to display above your business listing.', 'lsx-business-directory' ),
 				'id'   => $this->prefix . '_banner',
 				'type' => 'file',
 			)
 		);
-
 		$cmb_images->add_field(
 			array(
-				'name'    => esc_html__( 'Banner Colour', 'lsx-business-directory' ),
-				'desc'    => esc_html__( 'Banner colour if Banner image is missing.', 'lsx-business-directory' ),
+				'name'    => esc_html__( 'Colour', 'lsx-business-directory' ),
+				'desc'    => esc_html__( 'Choose a background colour to display in case you don\'t have a banner image.', 'lsx-business-directory' ),
 				'id'      => $this->prefix . '_banner_colour',
 				'type'    => 'colorpicker',
 				'default' => '#ffffff',
+			)
+		);
+		$cmb_images->add_field(
+			array(
+				'name' => esc_html__( 'Title', 'lsx-business-directory' ),
+				'desc' => esc_html__( 'Customize the title for your banner.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_banner_title',
+				'type' => 'text',
+			)
+		);
+		$cmb_images->add_field(
+			array(
+				'name' => esc_html__( 'Subtitle', 'lsx-business-directory' ),
+				'desc' => esc_html__( 'Customize the subtitle for your banner, this will display just below your title.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_banner_title',
+				'type' => 'text',
 			)
 		);
 	}

--- a/classes/class-business-directory.php
+++ b/classes/class-business-directory.php
@@ -41,6 +41,9 @@ class Business_Directory {
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_action( 'init', array( $this, 'taxonomy_setup' ) );
+
+		// Register the custom fields.
+		add_action( 'cmb2_init', array( $this, 'register_banner_custom_fields' ) );
 		add_action( 'cmb2_init', array( $this, 'configure_business_directory_custom_fields' ) );
 	}
 
@@ -180,16 +183,17 @@ class Business_Directory {
 		$post_types[] = $this->slug;
 		return $post_types;
 	}
+
 	/**
 	 * Configure Business Directory custom fields.
 	 *
 	 * @return void
 	 */
-	public function configure_business_directory_custom_fields() {
+	public function register_banner_custom_fields() {
 		$cmb_images = new_cmb2_box(
 			array(
-				'id'           => $this->prefix . '_images_metabox',
-				'title'        => esc_html__( 'Business Images', 'lsx-business-directory' ),
+				'id'           => $this->prefix . '_banner_images_metabox',
+				'title'        => esc_html__( 'Business Banner', 'lsx-business-directory' ),
 				'object_types' => array( 'business-directory' ),
 			)
 		);
@@ -212,7 +216,14 @@ class Business_Directory {
 				'default' => '#ffffff',
 			)
 		);
+	}
 
+	/**
+	 * Configure Business Directory custom fields.
+	 *
+	 * @return void
+	 */
+	public function configure_business_directory_custom_fields() {
 		$cmb_address = new_cmb2_box(
 			array(
 				'id'           => $this->prefix . '_address_metabox',

--- a/classes/class-business-directory.php
+++ b/classes/class-business-directory.php
@@ -196,15 +196,6 @@ class Business_Directory {
 
 		$cmb_images->add_field(
 			array(
-				'name' => esc_html__( 'Featured Image', 'lsx-business-directory' ),
-				'desc' => esc_html__( 'Featured image for a Business', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_logo',
-				'type' => 'file',
-			)
-		);
-
-		$cmb_images->add_field(
-			array(
 				'name' => esc_html__( 'Banner Image', 'lsx-business-directory' ),
 				'desc' => esc_html__( 'Banner image for a Business', 'lsx-business-directory' ),
 				'id'   => $this->prefix . '_banner',

--- a/classes/class-business-directory.php
+++ b/classes/class-business-directory.php
@@ -227,85 +227,6 @@ class Business_Directory {
 	 * @return void
 	 */
 	public function register_address_custom_fields() {
-	}
-
-	/**
-	 * Registers the Business Directory branches custom fields.
-	 *
-	 * @return void
-	 */
-	public function register_branches_custom_fields() {
-	}
-
-	/**
-	 * Registers the Business Directory contact custom fields.
-	 *
-	 * @return void
-	 */
-	public function register_contact_custom_fields() {
-		$cmb_contact = new_cmb2_box(
-			array(
-				'id'           => $this->prefix . '_contact_metabox',
-				'title'        => esc_html__( 'Contact Details.', 'lsx-business-directory' ),
-				'object_types' => array( 'business-directory' ),
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Primary Email.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_primary_email',
-				'type' => 'text_email',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Secondary Email.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_secondary_email',
-				'type' => 'text_email',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Primary Phone.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_primary_phone',
-				'type' => 'text',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Secondary Phone.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_secondary_phone',
-				'type' => 'text',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Fax.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_fax',
-				'type' => 'text',
-			)
-		);
-
-		$cmb_contact->add_field(
-			array(
-				'name' => esc_html__( 'Website.', 'lsx-business-directory' ),
-				'id'   => $this->prefix . '_website',
-				'type' => 'text_url',
-			)
-		);
-	}
-
-	/**
-	 * Configure Business Directory custom fields.
-	 *
-	 * @return void
-	 */
-	public function configure_business_directory_custom_fields() {
 		$cmb_address = new_cmb2_box(
 			array(
 				'id'           => $this->prefix . '_address_metabox',
@@ -380,7 +301,14 @@ class Business_Directory {
 				'type' => 'text',
 			)
 		);
+	}
 
+	/**
+	 * Registers the Business Directory branches custom fields.
+	 *
+	 * @return void
+	 */
+	public function register_branches_custom_fields() {
 		$branches_group_field_id = $cmb_address->add_field(
 			array(
 				'id'          => $this->prefix . '_business_branches',
@@ -444,5 +372,76 @@ class Business_Directory {
 				'type' => 'text',
 			)
 		);
+	}
+
+	/**
+	 * Registers the Business Directory contact custom fields.
+	 *
+	 * @return void
+	 */
+	public function register_contact_custom_fields() {
+		$cmb_contact = new_cmb2_box(
+			array(
+				'id'           => $this->prefix . '_contact_metabox',
+				'title'        => esc_html__( 'Contact Details.', 'lsx-business-directory' ),
+				'object_types' => array( 'business-directory' ),
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Primary Email.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_primary_email',
+				'type' => 'text_email',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Secondary Email.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_secondary_email',
+				'type' => 'text_email',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Primary Phone.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_primary_phone',
+				'type' => 'text',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Secondary Phone.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_secondary_phone',
+				'type' => 'text',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Fax.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_fax',
+				'type' => 'text',
+			)
+		);
+
+		$cmb_contact->add_field(
+			array(
+				'name' => esc_html__( 'Website.', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_website',
+				'type' => 'text_url',
+			)
+		);
+	}
+
+	/**
+	 * Configure Business Directory custom fields.
+	 *
+	 * @return void
+	 */
+	public function configure_business_directory_custom_fields() {
 	}
 }

--- a/classes/class-business-directory.php
+++ b/classes/class-business-directory.php
@@ -40,7 +40,8 @@ class Business_Directory {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_post_type' ) );
-		add_action( 'init', array( $this, 'taxonomy_setup' ) );
+		add_action( 'init', array( $this, 'register_industry_taxonomy' ) );
+		add_action( 'init', array( $this, 'register_region_taxonomy' ) );
 
 		// Register the custom fields.
 		add_action( 'cmb2_init', array( $this, 'register_banner_custom_fields' ) );
@@ -118,9 +119,9 @@ class Business_Directory {
 	}
 
 	/**
-	 * Register the Week taxonomy.
+	 * Registers the Industry taxonomy for the Business Directory.
 	 */
-	public function taxonomy_setup() {
+	public function register_industry_taxonomy() {
 		$labels = array(
 			'name'              => esc_html__( 'Industry', 'lsx-business-directory' ),
 			'singular_name'     => esc_html__( 'Industry', 'lsx-business-directory' ),
@@ -134,7 +135,6 @@ class Business_Directory {
 			'new_item_name'     => esc_html__( 'New Industry', 'lsx-business-directory' ),
 			'menu_name'         => esc_html__( 'Industries', 'lsx-business-directory' ),
 		);
-
 		$details = array(
 			'labels'              => $labels,
 			'hierarchical'        => true,
@@ -145,9 +145,13 @@ class Business_Directory {
 			'query_var'           => true,
 			'rewrite'             => array( 'industry' ),
 		);
-
 		register_taxonomy( 'lsx-bd-industry', array( $this->slug ), $details );
+	}
 
+	/**
+	 * Registers the Industry region for the Business Directory.
+	 */
+	public function register_region_taxonomy() {
 		$labels = array(
 			'name'              => esc_html__( 'Region', 'lsx-business-directory' ),
 			'singular_name'     => esc_html__( 'Region', 'lsx-business-directory' ),
@@ -161,7 +165,6 @@ class Business_Directory {
 			'new_item_name'     => esc_html__( 'New Region', 'lsx-business-directory' ),
 			'menu_name'         => esc_html__( 'Regions', 'lsx-business-directory' ),
 		);
-
 		$details = array(
 			'labels'              => $labels,
 			'hierarchical'        => true,
@@ -172,9 +175,9 @@ class Business_Directory {
 			'query_var'           => true,
 			'rewrite'             => array( 'region' ),
 		);
-
 		register_taxonomy( 'lsx-bd-region', array( $this->slug ), $details );
 	}
+
 	/**
 	 * Adds the post type to the different arrays.
 	 *

--- a/classes/class-business-directory.php
+++ b/classes/class-business-directory.php
@@ -235,6 +235,13 @@ class Business_Directory {
 				'type' => 'text',
 			)
 		);
+		$cmb_images->add_field(
+			array(
+				'name' => esc_html__( 'Disable Banner', 'lsx-business-directory' ),
+				'id'   => $this->prefix . '_banner_disable',
+				'type' => 'checkbox',
+			)
+		);
 	}
 
 	/**

--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -18,9 +18,17 @@ class Frontend {
 	protected static $instance = null;
 
 	/**
+	 * Holds the frontend banner actions and filters.
+	 *
+	 * @var object \lsx\business_directory\classes\frontend\Banners();
+	 */
+	public $banners;
+
+	/**
 	 * Contructor
 	 */
 	public function __construct() {
+		$this->load_classes();
 		add_action( 'wp_enqueue_scripts', array( $this, 'assets' ), 5 );
 
 		// Handle the template redirects.
@@ -44,6 +52,15 @@ class Frontend {
 			self::$instance = new self();
 		}
 		return self::$instance;
+	}
+
+	/**
+	 * Loads the variable classes and the static classes.
+	 */
+	private function load_classes() {
+		// Load plugin admin related functionality.
+		require_once LSX_BD_PATH . 'classes/frontend/class-banners.php';
+		$this->banners = frontend\Banners::get_instance();
 	}
 
 	/**

--- a/classes/frontend/class-banners.php
+++ b/classes/frontend/class-banners.php
@@ -37,4 +37,20 @@ class Banners {
 		}
 		return self::$instance;
 	}
+
+	/**
+	 * Outputs the single
+	 *
+	 * @return void
+	 */
+	public function single_listing_banner() {
+		?>
+		<div class="wp-block-cover alignfull has-background-dim" style="background-image:url(https://lsx-business-directory.lsdev.biz/wp-content/uploads/2020/03/taranaki-mountain-scaled.jpg)">
+			<div class="wp-block-cover__inner-container">
+				<h2 class="has-text-align-center">LightSpeed Apex</h2>
+				<p class="has-text-align-center">Designs at its peak</p>
+			</div>
+		</div>
+		<?php
+	}
 }

--- a/classes/frontend/class-banners.php
+++ b/classes/frontend/class-banners.php
@@ -21,6 +21,7 @@ class Banners {
 	 * Contructor
 	 */
 	public function __construct() {
+		add_action( 'lsx_entry_top', array( $this, 'single_listing_banner' ) );
 	}
 
 	/**
@@ -44,13 +45,36 @@ class Banners {
 	 * @return void
 	 */
 	public function single_listing_banner() {
-		?>
-		<div class="wp-block-cover alignfull has-background-dim" style="background-image:url(https://lsx-business-directory.lsdev.biz/wp-content/uploads/2020/03/taranaki-mountain-scaled.jpg)">
-			<div class="wp-block-cover__inner-container">
-				<h2 class="has-text-align-center">LightSpeed Apex</h2>
-				<p class="has-text-align-center">Designs at its peak</p>
+		$disable = get_post_meta( get_the_ID(), 'lsx_bd_banner_disable', true );
+		if ( true !== $disable && 'on' !== $disable ) {
+			$image  = get_post_meta( get_the_ID(), 'lsx_bd_banner', true );
+			$colour = get_post_meta( get_the_ID(), 'lsx_bd_banner_colour', true );
+			if ( false === $colour || '' === $colour ) {
+				$colour = '#333';
+			}
+			$title    = get_post_meta( get_the_ID(), 'lsx_bd_banner_title', true );
+			$subtitle = get_post_meta( get_the_ID(), 'lsx_bd_banner_subtitle', true );
+
+			$background_image_attr = '';
+			if ( '' === $image || false === $image ) {
+				$background_image_attr = 'background-color:' . $colour;
+			} else {
+				$background_image_attr = 'background-image:url(' . $image . ')';
+			}
+			?>
+			<div class="wp-block-cover alignfull has-background-dim" style="<?php echo esc_html( $background_image_attr ); ?>">
+				<div class="wp-block-cover__inner-container">
+					<?php if ( '' !== $title && false !== $title ) { ?>
+						<h2 class="has-text-align-center"><?php echo esc_html( $title ); ?></h2>
+					<?php } ?>
+
+					<?php if ( '' !== $subtitle && false !== $subtitle ) { ?>
+						<p class="has-text-align-center"><?php echo esc_html( $subtitle ); ?></p>
+					<?php } ?>
+				</div>
 			</div>
-		</div>
-		<?php
+			<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
+			<?php
+		}
 	}
 }

--- a/classes/frontend/class-banners.php
+++ b/classes/frontend/class-banners.php
@@ -1,0 +1,40 @@
+<?php
+namespace lsx\business_directory\classes\frontend;
+
+/**
+ * Banners Frontend Class
+ *
+ * @package lsx-business-directory
+ */
+class Banners {
+
+	/**
+	 * Holds class instance
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      object \lsx\business_directory\classes\frontend\Banners()
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Contructor
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return    object \lsx\business_directory\classes\frontend\Banners()    A single instance of this class.
+	 */
+	public static function get_instance() {
+		// If the single instance hasn't been set, set it now.
+		if ( null == self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+}

--- a/classes/integrations/class-lsx-search.php
+++ b/classes/integrations/class-lsx-search.php
@@ -232,7 +232,7 @@ class LSX_Search {
 	 */
 	public function lsx_search_prefix( $prefix = '' ) {
 		if ( is_post_type_archive( 'business-directory' ) ) {
-			$prefix       = 'archive';
+			$prefix = 'archive';
 		}
 		return $prefix;
 	}

--- a/templates/single-business-directory.php
+++ b/templates/single-business-directory.php
@@ -19,7 +19,6 @@ get_header(); ?>
 		while ( have_posts() ) :
 			the_post();
 			$prefix                      = 'lsx_bd';
-			$business_logo               = get_post_meta( get_the_ID(), $prefix . '_logo', true );
 			$business_banner             = get_post_meta( get_the_ID(), $prefix . '_banner', true );
 			$business_google_maps_search = get_post_meta( get_the_ID(), $prefix . '_address_google_maps_search', true );
 			$business_address_1          = get_post_meta( get_the_ID(), $prefix . '_address_street_number', true );


### PR DESCRIPTION
### Description of the Change
The following has been done in order to create a banner on the single listing page.
- Added in the banners frontend and backend classes.
- Removing the featured image custom field.
- Separated the banner fields into its own functions
- Separating the contact custom fields into its own functions
- Split the branches and the address fields.
- Removed the empty custom fields box.
- Split the register taxonomy functions.
- Adding in the banner title and banner subtitle custom fields.
- Fixing the banner title field
- Adding a banner disable field, and a function to output a banner.
- Making the banner function dynamic.

### Benefits
I have used the WP Cover block type html output so it inherits the block styling.  When we eventually switch over to blocks it should be a more seamless transition.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues
#29 
