### PR TITLE
Phase-1/fix/27 - When selecting and enquiry form, the button does not show on the single listing

### DIFF
--- a/classes/class-core.php
+++ b/classes/class-core.php
@@ -48,9 +48,9 @@ class Core {
 	 * Contructor
 	 */
 	public function __construct() {
+		$this->load_includes();
 		$this->load_vendors();
 		$this->load_classes();
-		$this->load_includes();
 	}
 
 	/**

--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -32,6 +32,13 @@ class Frontend {
 	public $banners;
 
 	/**
+	 * Enquiry form.
+	 *
+	 * @var object \lsx\business_directory\classes\frontend\Enquiry();
+	 */
+	public $enquiry;
+
+	/**
 	 * Contructor
 	 */
 	public function __construct() {
@@ -65,6 +72,9 @@ class Frontend {
 
 		require_once LSX_BD_PATH . 'classes/frontend/class-banners.php';
 		$this->banners = frontend\Banners::get_instance();
+
+		require_once LSX_BD_PATH . 'classes/frontend/class-enquiry.php';
+		$this->enquiry = frontend\Enquiry::get_instance();
 	}
 
 	/**

--- a/classes/frontend/class-enquiry.php
+++ b/classes/frontend/class-enquiry.php
@@ -93,27 +93,35 @@ class Enquiry {
 							<?php
 							switch ( $this->form_type ) {
 								case 'wp':
-									// $this->form = \RGFormsModel::get_form( $this->form_id );
-									// $form       = \GFForms::get_form( $this->form_id, false, false, false, null, true );
-									// echo $form; // @codingStandardsIgnoreLine
-									echo 'WPFORM ENQUIRY FORM';
+									if ( class_exists( 'WPForms' ) ) {
+										echo do_shortcode( '[wpforms id="' . $this->form_id . '"]' );
+									} else {
+										echo 'Enable WPForms plugin.';
+									}
 									break;
 								case 'ninja':
-									// $this->form = \RGFormsModel::get_form( $this->form_id );
-									// $form       = \GFForms::get_form( $this->form_id, false, false, false, null, true );
-									// echo $form; // @codingStandardsIgnoreLine
-									echo "NINJA ENQUIRY FORM";
+									if ( class_exists( 'Ninja_Forms' ) ) {
+										echo do_shortcode( '[ninja_form id="' . $this->form_id . '"]' );
+									} else {
+										echo 'Enable Ninja Forms plugin.';
+									}
 									break;
 								case 'gravity':
-									$this->form = \RGFormsModel::get_form( $this->form_id );
-									$form       = \GFForms::get_form( $this->form_id, false, false, false, null, true );
-									echo $form; // @codingStandardsIgnoreLine
+									if ( class_exists( 'GFForms' ) ) {
+										// $this->form = \RGFormsModel::get_form( $this->form_id );
+										// $form       = \GFForms::get_form( $this->form_id, false, false, false, null, true );
+										// echo $form; // @codingStandardsIgnoreLine
+										echo do_shortcode( '[gravityform id="' . $this->form_id . '" title="false" description="false" ajax="true"]' );
+									} else {
+										echo 'Enable Gravity Forms plugin.';
+									}
 									break;
 								case 'caldera':
-									// $this->form = \RGFormsModel::get_form( $this->form_id );
-									// $form       = \GFForms::get_form( $this->form_id, false, false, false, null, true );
-									// echo $form; // @codingStandardsIgnoreLine
-									echo "CALDERA ENQUIRY FORM";
+									if ( class_exists( 'Caldera_Forms_Forms' ) ) {
+										echo do_shortcode( '[caldera_form id="' . $this->form_id . '"]' );
+									} else {
+										echo 'Enable Caldera Forms plugin.';
+									}
 									break;
 								default:
 									echo 'NO FORM';

--- a/classes/frontend/class-enquiry.php
+++ b/classes/frontend/class-enquiry.php
@@ -1,0 +1,129 @@
+<?php
+namespace lsx\business_directory\classes\frontend;
+
+/**
+ * Enquiry Frontend Class
+ *
+ * @package lsx-business-directory
+ */
+class Enquiry {
+
+	/**
+	 * Holds class instance
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      object \lsx\business_directory\classes\frontend\Enquiry()
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Holds the enquiry form ID.
+	 *
+	 * @var int
+	 */
+	public $form_id = false;
+
+	/**
+	 * Holds the enquiry form type.
+	 *
+	 * @var int
+	 */
+	public $form_type = false;
+
+	/**
+	 * Holds the enquiry form model.
+	 *
+	 * @var object
+	 */
+	public $form = false;
+
+	/**
+	 * Initialize the plugin by setting localization, filters, and administration functions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @access private
+	 */
+	private function __construct() {
+		add_action( 'wp_footer', array( $this, 'output_enquiry_form' ) );
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return    object \lsx\business_directory\classes\frontend\Enquiry()    A single instance of this class.
+	 */
+	public static function get_instance() {
+		// If the single instance hasn't been set, set it now.
+		if ( null == self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Outputs the enquiry form wrapped in a bootstrap modal.
+	 *
+	 * @return  void
+	 */
+	public function output_enquiry_form() {
+		$enquiry_form = lsx_bd_get_option( 'single_enquiry_form' );
+
+		if ( $enquiry_form ) {
+			$enquiry_form_data = explode( '_', $enquiry_form );
+			$this->form_type   = $enquiry_form_data[0];
+			$this->form_id     = $enquiry_form_data[1];
+		}
+
+		if ( false !== $this->form_id && null !== $this->form_id && 0 !== $this->form_id ) {
+			?>
+			<div id="enquiry-form-modal" class="modal" tabindex="-1" role="dialog">
+				<div class="modal-dialog" role="document">
+					<div class="modal-content">
+						<div class="modal-header">
+							<h3 class="modal-title"><?php esc_html_e( 'Contact', 'lsx-business-directory' ); ?> <?php the_title(); ?></h3>
+							<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+							<span aria-hidden="true">&times;</span>
+							</button>
+						</div>
+						<div class="modal-body">
+							<?php
+							switch ( $this->form_type ) {
+								case 'wp':
+									// $this->form = \RGFormsModel::get_form( $this->form_id );
+									// $form       = \GFForms::get_form( $this->form_id, false, false, false, null, true );
+									// echo $form; // @codingStandardsIgnoreLine
+									echo 'WPFORM ENQUIRY FORM';
+									break;
+								case 'ninja':
+									// $this->form = \RGFormsModel::get_form( $this->form_id );
+									// $form       = \GFForms::get_form( $this->form_id, false, false, false, null, true );
+									// echo $form; // @codingStandardsIgnoreLine
+									echo "NINJA ENQUIRY FORM";
+									break;
+								case 'gravity':
+									$this->form = \RGFormsModel::get_form( $this->form_id );
+									$form       = \GFForms::get_form( $this->form_id, false, false, false, null, true );
+									echo $form; // @codingStandardsIgnoreLine
+									break;
+								case 'caldera':
+									// $this->form = \RGFormsModel::get_form( $this->form_id );
+									// $form       = \GFForms::get_form( $this->form_id, false, false, false, null, true );
+									// echo $form; // @codingStandardsIgnoreLine
+									echo "CALDERA ENQUIRY FORM";
+									break;
+								default:
+									echo 'NO FORM';
+							}
+							?>
+						</div>
+					</div>
+				</div>
+			</div>
+			<?php
+		}
+	}
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -277,12 +277,14 @@ function lsx_bd_get_country_options() {
  * Value = Form Name
  */
 function lsx_bd_get_available_forms() {
-	$forms   = lsx_bd_get_activated_forms();
-	$options = array();
+	$forms_data = lsx_bd_get_activated_forms();
+	$options    = array();
 
-	if ( ! empty( $forms ) ) {
-		foreach ( $forms as $form_id => $form_data ) {
-			$options[ $form_id ] = strval( $form_data );
+	if ( ! empty( $forms_data ) ) {
+		$type = $forms_data['form_type'];
+		$data = $forms_data['form_data'];
+		foreach ( $data as $form_id => $form_data ) {
+			$options[ "{$type}_{$form_id}" ] = strval( $form_data );
 		}
 	} else {
 		$options['none'] = esc_html__( 'You have no forms available', 'lsx-business-directory' );
@@ -298,18 +300,26 @@ function lsx_bd_get_available_forms() {
  */
 function lsx_bd_get_activated_forms() {
 	$all_forms = false;
+	$form_type = null;
 
 	if ( class_exists( 'WPForms' ) ) {
 		$all_forms = lsx_bd_get_wpforms();
+		$form_type = 'wp';
 	} elseif ( class_exists( 'Ninja_Forms' ) ) {
 		$all_forms = lsx_bd_get_ninja_forms();
+		$form_type = 'ninja';
 	} elseif ( class_exists( 'GFForms' ) ) {
 		$all_forms = lsx_bd_get_gravity_forms();
+		$form_type = 'gravity';
 	} elseif ( class_exists( 'Caldera_Forms_Forms' ) ) {
 		$all_forms = lsx_bd_get_caldera_forms();
+		$form_type = 'caldera';
 	}
 
-	return $all_forms;
+	return array(
+		'form_data' => $all_forms,
+		'form_type' => $form_type,
+	);
 }
 
 /**
@@ -410,6 +420,7 @@ function lsx_bd_get_caldera_forms() {
  */
 function lsx_bd_get_option( $key = '' ) {
 	$value = false;
+
 	if ( '' !== $key && function_exists( 'cmb2_get_option' ) ) {
 		$value = cmb2_get_option( 'lsx-business-directory-settings', $key, false );
 	}

--- a/templates/single-business-directory.php
+++ b/templates/single-business-directory.php
@@ -19,6 +19,7 @@ get_header(); ?>
 		while ( have_posts() ) :
 			the_post();
 			$prefix                      = 'lsx_bd';
+			$business_enquiry_form       = lsx_bd_get_option( 'single_enquiry_form' );
 			$business_banner             = get_post_meta( get_the_ID(), $prefix . '_banner', true );
 			$business_google_maps_search = get_post_meta( get_the_ID(), $prefix . '_address_google_maps_search', true );
 			$business_address_1          = get_post_meta( get_the_ID(), $prefix . '_address_street_number', true );
@@ -52,10 +53,6 @@ get_header(); ?>
 			if ( $business_address_4 ) {
 				$address[] = $business_address_4;
 			}
-
-			// if ( $business_postal_code ) {
-			// $address[] = $business_postal_code;
-			// }
 
 			if ( $business_province ) {
 				$address[] = $business_province;
@@ -109,7 +106,7 @@ get_header(); ?>
 				<div class="row">
 					<div class="col-md-4">
 						<div class="contact-info business-content-section">
-							<h4 class="business-section-title">Contact Information</h4>
+							<h4 class="business-section-title"><?php esc_html_e( 'Contact Information', 'lsx-business-directory' ); ?></h4>
 
 							<div class="row">
 								<div class="col-md-6">
@@ -148,26 +145,22 @@ get_header(); ?>
 							</div>
 						</div>
 
-						<div class="contact-form business-content-section">
-							<h4 class="business-section-title">Contact <?php the_title(); ?></h4>
-							<?php
-							if ( class_exists( 'Caldera_Forms' ) ) {
-								$form_slug = get_option( 'lsx-business-directory-generic-form' );
-								echo esc_attr( Caldera_Forms::render_form( $form_slug ) );
-							}
-							?>
+						<?php if ( $business_enquiry_form ) : ?>
+						<div>
+							<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#enquiry-form-modal"><?php esc_html_e( 'Contact', 'lsx-business-directory' ); ?> <?php the_title(); ?></button>
 						</div>
+						<?php endif; ?>
 					</div>
 
 					<div class="col-md-8">
 						<div class="business-description business-content-section">
-							<h3 class="business-section-title">Description</h3>
+							<h3 class="business-section-title"><?php esc_html_e( 'Description', 'lsx-business-directory' ); ?></h3>
 							<?php the_content(); ?>
 						</div>
 
 						<?php if ( ! empty( $branches ) && is_array( $branches ) && isset( $branches[0]['branch_name'] ) && '' !== $branches[0]['branch_name'] ) : ?>
 							<div class="branches business-content-section">
-								<h3 class="business-section-title">Branches</h3>
+								<h3 class="business-section-title"><?php esc_html_e( 'Branches', 'lsx-business-directory' ); ?></h3>
 								<?php
 								foreach ( $branches as $branch ) {
 									lsx_business_branch( $branch ); // TODO
@@ -239,7 +232,7 @@ get_header(); ?>
 				if ( $related_business_query->have_posts() ) :
 					?>
 					<div class="related-businesses">
-						<h2>Related Businesses</h2>
+						<h2><?php esc_html_e( 'Related Businesses', 'lsx-business-directory' ); ?></h2>
 						<div class="row">
 							<?php while ( $related_business_query->have_posts() ) : ?>
 								<?php $related_business_query->the_post(); ?>


### PR DESCRIPTION
### Description
Enquiry button on a single template was not working. There should be a button present on a single template which on click brings up a modal form for Enquiry for a particular listing.

### Code changes
- Modified **class-frontend.php** to include new **class-enquiry.php** file.
- Modified **functions.php** to add support for multiple Form plugins.
- Modified **single-business-directory.php** template to add a button for a modal popup.
- Added a new **class-enquiry.php** file which deals with modal popup form with multiple Form plugins support.

### Tests done
- Tested WPForms plugin form in a modal popup.
- Tested Ajax setting when form is submitted with errors, page does not refresh.
- Tested modal popup behavior when Form plugin is not enabled.

### Issue
https://github.com/lightspeeddevelopment/lsx-business-directory/issues/27