### PR TITLE
Removing the `using-gutenberg` body class when the listing is using blocks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,9 @@
+# Change log
+
+## 1.1.0 - Unreleased
+
+### Fixed
+- Removing the `using-gutenberg` body class when the listing is using blocks.
+
+## 1.0.0 - 30 March 2020
+Initial release

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,0 @@
-## Change log
-
-### 1.0.0
-* Initial release

--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -57,7 +57,7 @@ class Frontend {
 	 */
 	public function __construct() {
 		$this->load_classes();
-		add_filter( 'body_class', array( $this, 'body_class' ), 10, 1 );
+		add_filter( 'body_class', array( $this, 'body_class' ), 200, 1 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'assets' ), 5 );
 		add_filter( 'get_the_archive_title', array( $this, 'get_the_archive_title' ), 100 );
 		add_filter( 'wp_kses_allowed_html', array( $this, 'wp_kses_allowed_html' ), 10, 2 );
@@ -110,6 +110,13 @@ class Frontend {
 
 			if ( is_singular( 'business-directory' ) ) {
 				$classes[] = 'lsx-body-full-width';
+
+				if ( function_exists( 'has_blocks' ) && has_blocks( get_the_ID() ) && ( ! is_search() ) && ( ! is_archive() ) ) {
+					$key = array_search( 'using-gutenberg', $classes );
+					if ( false !== $key ) {
+						unset( $classes[ $key ] );
+					}
+				}
 			} else {
 				$classes[] = 'lsx-body-full-width';
 				$prefix    = 'archive';


### PR DESCRIPTION
### Description of the Change
Removed the `using-gutenberg` body class when the listing is using blocks.

### Benefits
This allows you to use the WordPress blocks to format the listing description

### Verification Process
Without Blocks
![Screenshot 2020-03-30 at 15 44 38](https://user-images.githubusercontent.com/1805603/77920359-abbe5c00-729e-11ea-92e2-ff6d04d0c1ba.png)

With Blocks
![Screenshot 2020-03-30 at 15 52 20](https://user-images.githubusercontent.com/1805603/77920370-aeb94c80-729e-11ea-813f-e93f373b2b96.png)

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
[Bugherd 47](https://www.bugherd.com/projects/193258/tasks/47)

### Changelog Entry
Removing the `using-gutenberg` body class when the listing is using blocks.

