### PR TITLE
Add/slug translations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## 1.1.0 - Unreleased
 
+### Added
+- Added in a "Translations" settings tab to allow the translation of the post type and taxonomy slugs.
+
 ### Fixed
 - Removing the `using-gutenberg` body class when the listing is using blocks.
 - Removing the Bootstrap column classes breaking the padding of the single listings on mobile.

--- a/classes/admin/class-translations.php
+++ b/classes/admin/class-translations.php
@@ -66,7 +66,7 @@ class Translations {
 		);
 		$cmb->add_field(
 			array(
-				'name'    => esc_html__( 'Business Directory', 'lsx-business-directory' ),
+				'name'    => esc_html__( 'Listings Archive', 'lsx-business-directory' ),
 				'id'      => 'translations_listing_archive_slug',
 				'type'    => 'text',
 				'default' => 'listings',
@@ -74,7 +74,7 @@ class Translations {
 		);
 		$cmb->add_field(
 			array(
-				'name'    => esc_html__( 'Industries', 'lsx-business-directory' ),
+				'name'    => esc_html__( 'Industries Archives', 'lsx-business-directory' ),
 				'id'      => 'translations_industry_slug',
 				'type'    => 'text',
 				'default' => 'industry',
@@ -82,7 +82,7 @@ class Translations {
 		);
 		$cmb->add_field(
 			array(
-				'name'    => esc_html__( 'Locations', 'lsx-business-directory' ),
+				'name'    => esc_html__( 'Locations Archives', 'lsx-business-directory' ),
 				'id'      => 'translations_location_slug',
 				'type'    => 'text',
 				'default' => 'location',

--- a/classes/admin/class-translations.php
+++ b/classes/admin/class-translations.php
@@ -72,6 +72,22 @@ class Translations {
 				'default' => 'listings',
 			)
 		);
+		$cmb->add_field(
+			array(
+				'name'    => esc_html__( 'Industries', 'lsx-business-directory' ),
+				'id'      => 'translations_industry_slug',
+				'type'    => 'text',
+				'default' => 'industry',
+			)
+		);
+		$cmb->add_field(
+			array(
+				'name'    => esc_html__( 'Locations', 'lsx-business-directory' ),
+				'id'      => 'translations_location_slug',
+				'type'    => 'text',
+				'default' => 'location',
+			)
+		);
 		do_action( 'lsx_bd_settings_section_translations', $cmb, 'bottom' );
 		$cmb->add_field(
 			array(

--- a/classes/admin/class-translations.php
+++ b/classes/admin/class-translations.php
@@ -21,7 +21,7 @@ class Translations {
 	 * Contructor
 	 */
 	public function __construct() {
-		add_action( 'lsx_bd_settings_page', array( $this, 'register_settings_translations' ), 1, 1 );
+		add_action( 'lsx_bd_settings_page', array( $this, 'register_settings_translations' ), 30, 1 );
 	}
 
 	/**
@@ -52,14 +52,14 @@ class Translations {
 				'type'        => 'title',
 				'name'        => __( 'Translations', 'lsx-business-directory' ),
 				'default'     => __( 'Translations', 'lsx-business-directory' ),
-				'description' => __( 'Change the slugs for your the listings, industry and regions.', 'lsx-business-directory' ),
+				'description' => __( 'Change the slugs for your the listings, industry and regions. Once you have saved your settings, open the <a href="/wp-admin/options-permalink.php">permalinks</a> page to flush the rewrite rules.', 'lsx-business-directory' ),
 			)
 		);
 		do_action( 'lsx_bd_settings_section_translations', $cmb, 'top' );
 		$cmb->add_field(
 			array(
 				'name'    => esc_html__( 'Listing Single', 'lsx-business-directory' ),
-				'id'      => 'translation_listing_single_slug',
+				'id'      => 'translations_listing_single_slug',
 				'type'    => 'text',
 				'default' => 'listing',
 			)
@@ -67,7 +67,7 @@ class Translations {
 		$cmb->add_field(
 			array(
 				'name'    => esc_html__( 'Business Directory', 'lsx-business-directory' ),
-				'id'      => 'translation_listing_archive_slug',
+				'id'      => 'translations_listing_archive_slug',
 				'type'    => 'text',
 				'default' => 'listings',
 			)

--- a/classes/admin/class-translations.php
+++ b/classes/admin/class-translations.php
@@ -52,7 +52,7 @@ class Translations {
 				'type'        => 'title',
 				'name'        => __( 'Translations', 'lsx-business-directory' ),
 				'default'     => __( 'Translations', 'lsx-business-directory' ),
-				'description' => __( 'Change the slugs for your the listings, industry and regions. Once you have saved your settings, open the <a href="/wp-admin/options-permalink.php">permalinks</a> page to flush the rewrite rules.', 'lsx-business-directory' ),
+				'description' => __( 'Change the slugs for your the listings, industry and regions. Once you have saved your settings, open the <a href="/wp-admin/options-permalink.php">permalinks</a> page to flush the rewrite rules.  This is only for the URLs.', 'lsx-business-directory' ),
 			)
 		);
 		do_action( 'lsx_bd_settings_section_translations', $cmb, 'top' );

--- a/classes/admin/class-translations.php
+++ b/classes/admin/class-translations.php
@@ -1,0 +1,83 @@
+<?php
+namespace lsx\business_directory\classes\admin;
+
+/**
+ * THis class holds the translation options
+ *
+ * @package lsx-business-directory
+ */
+class Translations {
+
+	/**
+	 * Holds class instance
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      object \lsx\business_directory\classes\admin\Translations()
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Contructor
+	 */
+	public function __construct() {
+		add_action( 'lsx_bd_settings_page', array( $this, 'register_settings_translations' ), 1, 1 );
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return    object \lsx\business_directory\classes\admin\Translations()    A single instance of this class.
+	 */
+	public static function get_instance() {
+		// If the single instance hasn't been set, set it now.
+		if ( null == self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Configure Business Directory custom fields for the Settings page Translations section.
+	 *
+	 * @param object $cmb new_cmb2_box().
+	 * @return void
+	 */
+	public function register_settings_translations( $cmb ) {
+		$cmb->add_field(
+			array(
+				'id'          => 'settings_translations',
+				'type'        => 'title',
+				'name'        => __( 'Translations', 'lsx-business-directory' ),
+				'default'     => __( 'Translations', 'lsx-business-directory' ),
+				'description' => __( 'Change the slugs for your the listings, industry and regions.', 'lsx-business-directory' ),
+			)
+		);
+		do_action( 'lsx_bd_settings_section_translations', $cmb, 'top' );
+		$cmb->add_field(
+			array(
+				'name'    => esc_html__( 'Listing Single', 'lsx-business-directory' ),
+				'id'      => 'translation_listing_single_slug',
+				'type'    => 'text',
+				'default' => 'listing',
+			)
+		);
+		$cmb->add_field(
+			array(
+				'name'    => esc_html__( 'Business Directory', 'lsx-business-directory' ),
+				'id'      => 'translation_listing_archive_slug',
+				'type'    => 'text',
+				'default' => 'listings',
+			)
+		);
+		do_action( 'lsx_bd_settings_section_translations', $cmb, 'bottom' );
+		$cmb->add_field(
+			array(
+				'id'   => 'settings_translations_closing',
+				'type' => 'tab_closing',
+			)
+		);
+	}
+}

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -53,6 +53,13 @@ class Admin {
 	public $settings_theme;
 
 	/**
+	 * Holds the slug translations for the post type archives and taxonomies.
+	 *
+	 * @var object \lsx\business_directory\classes\admin\Translations();
+	 */
+	public $translations;
+
+	/**
 	 * Contructor
 	 */
 	public function __construct() {
@@ -100,6 +107,9 @@ class Admin {
 
 		require_once LSX_BD_PATH . 'classes/admin/class-settings-theme.php';
 		$this->settings_theme = admin\Settings_Theme::get_instance();
+
+		require_once LSX_BD_PATH . 'classes/admin/class-translations.php';
+		$this->translations = admin\Translations::get_instance();
 	}
 
 	/**

--- a/classes/class-core.php
+++ b/classes/class-core.php
@@ -48,8 +48,8 @@ class Core {
 	 * Contructor
 	 */
 	public function __construct() {
-		$this->load_includes();
 		$this->load_vendors();
+		$this->load_includes();
 		$this->load_classes();
 	}
 

--- a/classes/setup/class-business-directory.php
+++ b/classes/setup/class-business-directory.php
@@ -57,9 +57,9 @@ class Business_Directory {
 	 * Contructor
 	 */
 	public function __construct() {
-		add_action( 'init', array( $this, 'register_post_type' ) );
-		add_action( 'init', array( $this, 'register_industry_taxonomy' ) );
-		add_action( 'init', array( $this, 'register_region_taxonomy' ) );
+		add_action( 'init', array( $this, 'register_post_type' ), 20 );
+		add_action( 'init', array( $this, 'register_industry_taxonomy' ), 20 );
+		add_action( 'init', array( $this, 'register_region_taxonomy' ), 20 );
 
 		// Register the custom fields.
 		add_action( 'cmb2_init', array( $this, 'register_address_custom_fields' ), 10 );

--- a/classes/setup/class-business-directory.php
+++ b/classes/setup/class-business-directory.php
@@ -179,7 +179,9 @@ class Business_Directory {
 			'exclude_from_search' => true,
 			'show_admin_column'   => true,
 			'query_var'           => true,
-			'rewrite'             => array( 'slug' => lsx_bd_get_option( 'translations_industry_slug', $this->industry_slug ) ),
+			'rewrite'             => array(
+				'slug' => lsx_bd_get_option( 'translations_industry_slug', $this->industry_slug ),
+			),
 		);
 		register_taxonomy( 'industry', array( $this->slug ), $details );
 	}
@@ -210,7 +212,9 @@ class Business_Directory {
 			'exclude_from_search' => true,
 			'show_admin_column'   => true,
 			'query_var'           => true,
-			'rewrite'             => array( 'slug' => lsx_bd_get_option( 'translations_location_slug', $this->location_slug ) ),
+			'rewrite'             => array(
+				'slug' => lsx_bd_get_option( 'translations_location_slug', $this->location_slug ),
+			),
 		);
 		register_taxonomy( 'location', array( $this->slug ), $details );
 	}

--- a/classes/setup/class-business-directory.php
+++ b/classes/setup/class-business-directory.php
@@ -54,6 +54,24 @@ class Business_Directory {
 	public $archive_slug = 'listings';
 
 	/**
+	 * The Industry Term Slug
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      string
+	 */
+	public $industry_slug = 'industry';
+
+	/**
+	 * The Location Term Slug
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      string
+	 */
+	public $location_slug = 'location';
+
+	/**
 	 * Contructor
 	 */
 	public function __construct() {
@@ -161,7 +179,7 @@ class Business_Directory {
 			'exclude_from_search' => true,
 			'show_admin_column'   => true,
 			'query_var'           => true,
-			'rewrite'             => array( 'industry' ),
+			'rewrite'             => array( lsx_bd_get_option( 'translations_industry_slug', $this->industry_slug ) ),
 		);
 		register_taxonomy( 'industry', array( $this->slug ), $details );
 	}
@@ -192,7 +210,7 @@ class Business_Directory {
 			'exclude_from_search' => true,
 			'show_admin_column'   => true,
 			'query_var'           => true,
-			'rewrite'             => array( 'location' ),
+			'rewrite'             => array( lsx_bd_get_option( 'translations_location_slug', $this->location_slug ) ),
 		);
 		register_taxonomy( 'location', array( $this->slug ), $details );
 	}

--- a/classes/setup/class-business-directory.php
+++ b/classes/setup/class-business-directory.php
@@ -36,6 +36,24 @@ class Business_Directory {
 	public $prefix = 'lsx_bd';
 
 	/**
+	 * The Post Type Single Slug
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      string
+	 */
+	public $single_slug = 'listing';
+
+	/**
+	 * The Post Type Single Slug
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var      string
+	 */
+	public $archive_slug = 'listings';
+
+	/**
 	 * Contructor
 	 */
 	public function __construct() {
@@ -104,11 +122,11 @@ class Business_Directory {
 			'menu_icon'           => 'dashicons-list-view',
 			'query_var'           => true,
 			'rewrite'             => array(
-				'slug' => 'listing',
+				'slug' => lsx_bd_get_option( 'translations_listing_single_slug', $this->single_slug ),
 			),
 			'exclude_from_search' => false,
 			'capability_type'     => 'page',
-			'has_archive'         => 'listings',
+			'has_archive'         => lsx_bd_get_option( 'translations_listing_archive_slug', $this->archive_slug ),
 			'hierarchical'        => false,
 			'menu_position'       => null,
 			'supports'            => $supports,

--- a/classes/setup/class-business-directory.php
+++ b/classes/setup/class-business-directory.php
@@ -179,7 +179,7 @@ class Business_Directory {
 			'exclude_from_search' => true,
 			'show_admin_column'   => true,
 			'query_var'           => true,
-			'rewrite'             => array( lsx_bd_get_option( 'translations_industry_slug', $this->industry_slug ) ),
+			'rewrite'             => array( 'slug' => lsx_bd_get_option( 'translations_industry_slug', $this->industry_slug ) ),
 		);
 		register_taxonomy( 'industry', array( $this->slug ), $details );
 	}
@@ -210,7 +210,7 @@ class Business_Directory {
 			'exclude_from_search' => true,
 			'show_admin_column'   => true,
 			'query_var'           => true,
-			'rewrite'             => array( lsx_bd_get_option( 'translations_location_slug', $this->location_slug ) ),
+			'rewrite'             => array( 'slug' => lsx_bd_get_option( 'translations_location_slug', $this->location_slug ) ),
 		);
 		register_taxonomy( 'location', array( $this->slug ), $details );
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -280,6 +280,11 @@ function lsx_bd_get_option( $key = '', $default = false ) {
 	$value = $default;
 	if ( '' !== $key && function_exists( 'cmb2_get_option' ) ) {
 		$value = cmb2_get_option( 'lsx-business-directory-settings', $key, $default );
+	} else {
+		$options = get_option( 'lsx-business-directory-settings', false );
+		if ( false !== $options && isset( $options[ $key ] ) && '' !== $options[ $key ] ) {
+			$value = $options[ $key ];
+		}
 	}
 	return $value;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -273,12 +273,13 @@ function lsx_bd_get_country_options() {
  * Returns the current post type archive layout selection
  *
  * @param  string $key
+ * @param  string $default
  * @return string | boolean
  */
-function lsx_bd_get_option( $key = '' ) {
-	$value = false;
+function lsx_bd_get_option( $key = '', $default = false ) {
+	$value = $default;
 	if ( '' !== $key && function_exists( 'cmb2_get_option' ) ) {
-		$value = cmb2_get_option( 'lsx-business-directory-settings', $key, false );
+		$value = cmb2_get_option( 'lsx-business-directory-settings', $key, $default );
 	}
 	return $value;
 }

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -259,8 +259,8 @@ function lsx_bd_listing_title( $echo = true ) {
  */
 function lsx_bd_listing_meta( $echo = true ) {
 	$entry_meta = '';
-	$industries = lsx_bd_get_formatted_taxonomy_str( get_the_ID(), 'industry', true );
-	$locations  = lsx_bd_get_formatted_taxonomy_str( get_the_ID(), 'location', true );
+	$industries = get_the_term_list( get_the_ID(), 'industry', '', ', ', '' );
+	$locations  = get_the_term_list( get_the_ID(), 'location', '', ', ', '' );
 	if ( ! empty( $industries ) || ! empty( $locations ) ) {
 		$col_class = '6';
 		if ( empty( $industries ) || empty( $locations ) ) {
@@ -276,18 +276,7 @@ function lsx_bd_listing_meta( $echo = true ) {
 					<span>
 						<i class="fa fa-th"></i>
 						<strong><?php esc_html_e( 'Industry', 'lsx-business-directory' ); ?>: </strong>
-						<?php
-						$count = 0;
-						foreach ( $industries as $industry ) :
-							if ( $count > 0 ) :
-								?>,
-							<?php endif;
-							?>
-								<a href="/industry/<?php echo esc_attr( $industry['slug'] ); ?>"><?php echo esc_attr( $industry['name'] ); ?></a>
-								<?php
-								$count++;
-						endforeach;
-						?>
+						<?php echo wp_kses_post( $industries ); ?>
 					</span>
 				</div>
 				<?php
@@ -301,18 +290,7 @@ function lsx_bd_listing_meta( $echo = true ) {
 					<span>
 						<i class="fa fa-globe"></i>
 						<strong><?php esc_html_e( 'Location', 'lsx-business-directory' ); ?>: </strong>
-						<?php
-						$count = 0;
-						foreach ( $locations as $location ) :
-							if ( $count > 0 ) :
-								?>,
-							<?php endif;
-							?>
-								<a href="/location/<?php echo esc_attr( $location['slug'] ); ?>"><?php echo esc_attr( $location['name'] ); ?></a>
-								<?php
-								$count++;
-						endforeach;
-						?>
+						<?php echo wp_kses_post( $locations ); ?>
 					</span>
 				</div>
 				<?php

--- a/vendor/CMB2/init.php
+++ b/vendor/CMB2/init.php
@@ -67,7 +67,6 @@ if ( ! class_exists( 'CMB2_Bootstrap_270', false ) ) {
 				// We are running outside of the context of WordPress.
 				return;
 			}
-
 			add_action( 'init', array( $this, 'include_cmb' ), self::PRIORITY );
 		}
 


### PR DESCRIPTION
### Description of the Change
I have added in a settings tab to house the translations of the post type and the taxonomies. 

### Alternate Designs
![Screenshot 2020-03-31 at 12 31 15](https://user-images.githubusercontent.com/1805603/78017029-f649e200-734b-11ea-9081-8e330d394f33.png)

### Benefits
You will be able to change the slugs to anything you want.

### Possible Drawbacks
If you choose the same slug as one that exists it will cause problems when redirecting.

### Verification Process
- Navigate to the Settings Tab
- Change the slug of your choice, and save the settings.
- Open the permalinks page.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.


### Changelog Entry
Added in a "Translations" settings tab to allow the translation of the post type and taxonomy slugs.
